### PR TITLE
make negative prefixed numbers workd

### DIFF
--- a/NXP/Classes/TokenParser.php
+++ b/NXP/Classes/TokenParser.php
@@ -17,7 +17,7 @@ class TokenParser {
     const SPACE         = 'SPACE';
 
     private $terms = [
-        self::DIGIT         => '[0-9\.]',
+        self::DIGIT         => '[0-9\.\-]',
         self::CHAR          => '[a-z]',
         self::SPECIAL_CHAR  => '[\!\@\#\$\%\^\&\*\/\|\-\+\=\~]',
         self::LEFT_BRACKET  => '\(',


### PR DESCRIPTION
Fix the problem that negative prefixed numbers don't work.
E.g.: (3 + 5) \* -1
