### PR TITLE
Make TokenNumber aware of scientific notation

### DIFF
--- a/src/NXP/Classes/Token/TokenNumber.php
+++ b/src/NXP/Classes/Token/TokenNumber.php
@@ -20,6 +20,6 @@ class TokenNumber extends AbstractContainerToken
      */
     public static function getRegex()
     {
-        return '\-?\d+\.?\d*';
+        return '\-?\d+\.?\d*(E-?\d+)?';
     }
 }


### PR DESCRIPTION
Update the regex so scientific notation numbers work, e.g.:
'1 + 3.5E-8'
'1 + 3.5E8'
