### PR TITLE
fix a bug caused by more than two commas in the formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,15 @@ Simple math expressions calculator
 
 ## Install via Composer
 
-All instructions to install here: https://packagist.org/packages/nxp/math-executor
+Stable branch
+```
+composer require "nxp/math-executor" "dev-master"
+```
+
+Dev branch
+```
+composer require "nxp/math-executor" "dev-dev"
+```
 
 ## Sample usage:
 

--- a/src/NXP/Classes/Calculator.php
+++ b/src/NXP/Classes/Calculator.php
@@ -26,11 +26,13 @@ class Calculator
      * Calculate array of tokens in reverse polish notation
      * @param  array                                       $tokens    Array of tokens
      * @param  array                                       $variables Array of variables
+     * @param  array                                       $midresults Array of middle results
+     * @param  \NXP\MathExecutor                           $oExecutor object of NXP\MathExecutor
      * @return number                                      Result
      * @throws \NXP\Exception\IncorrectExpressionException
      * @throws \NXP\Exception\UnknownVariableException
      */
-    public function calculate($tokens, $variables)
+    public function calculate($tokens, $variables, $midresults, $oExecutor)
     {
         $stack = array();
         foreach ($tokens as $token) {
@@ -39,10 +41,25 @@ class Calculator
             }
             if ($token instanceof TokenVariable) {
                 $variable = $token->getValue();
+                if(array_key_exists($variable, $variables)) {
+                    $value = $variables[$variable];
+                } elseif (array_key_exists($variable, $midresults)) { //recursive calculation of intermediate result
+                    if(isset($midresults[$variable]['value'])) { //if intermediate has 'value' directly use it
+                        $value = $midresults[$variable]['value'];
+                    } else {
+                        $value = $oExecutor->execute($midresults[$variable]['formula']);
+                    }
+                } else {
+                    throw new UnknownVariableException();
+                }
+
+                /*
                 if (!array_key_exists($variable, $variables)) {
                     throw new UnknownVariableException();
                 }
                 $value = $variables[$variable];
+                */
+
                 array_push($stack, new TokenNumber($value));
             }
             if ($token instanceof InterfaceOperator || $token instanceof TokenFunction) {

--- a/src/NXP/Classes/Lexer.php
+++ b/src/NXP/Classes/Lexer.php
@@ -79,12 +79,28 @@ class Lexer
                 array_push($stack, $token);
             }
             if ($token instanceof TokenComma) {
+                //fix a bug caused by more than two commas in the formula
+                while($current = array_pop($stack)) {
+                    if (!$current instanceof TokenLeftBracket) {
+                        $output[] = $current;
+                    } else {
+                        array_push($stack, $current);
+                        break;
+                    }
+
+                    if (empty($stack)) {
+                        throw new IncorrectExpressionException();
+                    }
+                }
+
+                /*
                 while (($current = array_pop($stack)) && (!$current instanceof TokenLeftBracket)) {
                     $output[] = $current;
                     if (empty($stack)) {
                         throw new IncorrectExpressionException();
                     }
                 }
+                */
             }
             if ($token instanceof TokenRightBracket) {
                 while (($current = array_pop($stack)) && (!$current instanceof TokenLeftBracket)) {

--- a/src/NXP/Classes/Token/TokenFunction.php
+++ b/src/NXP/Classes/Token/TokenFunction.php
@@ -35,6 +35,9 @@ class TokenFunction extends AbstractContainerToken implements InterfaceFunction
             array_push($args, array_pop($stack)->getValue());
         }
         $result = call_user_func_array($function, $args);
+        if(is_nan($result)) { //set the "NAN" which return by php when use illegal parameters to a function like log(-1) to 0.0
+            $result = 0.0;
+        }
 
         return new TokenNumber($result);
     }

--- a/src/NXP/MathExecutor.php
+++ b/src/NXP/MathExecutor.php
@@ -30,6 +30,13 @@ class MathExecutor
     private $variables = array();
 
     /**
+     * middle results
+     *
+     * @var array
+     */
+    private $midresults = array();
+
+    /**
      * @var TokenFactory
      */
     private $tokenFactory;
@@ -45,11 +52,13 @@ class MathExecutor
     public function __construct()
     {
         $this->addDefaults();
+        $this->addCustomFunc();
     }
 
     public function __clone()
     {
         $this->addDefaults();
+        $this->addCustomFunc();
     }
 
     /**
@@ -73,12 +82,83 @@ class MathExecutor
         $this->tokenFactory->addFunction('atn', 'atan');
         $this->tokenFactory->addFunction('min', 'min', 2);
         $this->tokenFactory->addFunction('max', 'max', 2);
+        $this->tokenFactory->addFunction('log10', 'log10', 1);
+        $this->tokenFactory->addFunction('sqrt', 'sqrt', 1);
         $this->tokenFactory->addFunction('avg', function($arg1, $arg2) { return ($arg1 + $arg2) / 2; }, 2);
 
         $this->setVars(array(
             'pi' => 3.14159265359,
             'e'  => 2.71828182846
         ));
+    }
+
+    /**
+     * Set custom functions
+     */
+    protected function addCustomFunc() {
+        $this->tokenFactory->addFunction('log', function ($arg1, $arg2) { return log($arg2, $arg1); }, 2);
+        $this->tokenFactory->addFunction('gt', function ($arg1, $arg2, $arg3, $arg4) {
+            return $arg4 > $arg3 ? $arg2 : $arg1;
+        }, 4);
+        $this->tokenFactory->addFunction('egt', function ($arg1, $arg2, $arg3, $arg4) {
+            return $arg4 >= $arg3 ? $arg2 : $arg1;
+        }, 4);
+        $this->tokenFactory->addFunction('lt', function ($arg1, $arg2, $arg3, $arg4) {
+            return $arg4 < $arg3 ? $arg2 : $arg1;
+        }, 4);
+        $this->tokenFactory->addFunction('elt', function ($arg1, $arg2, $arg3, $arg4) {
+            return $arg4 <= $arg3 ? $arg2 : $arg1;
+        }, 4);
+        $this->tokenFactory->addFunction('eq', function ($arg1, $arg2, $arg3, $arg4) {
+            return $arg4 == $arg3 ? $arg2 : $arg1;
+        }, 4);
+        $this->addComplexFunc();
+    }
+
+    /**
+     * Set complex custom functions
+     */
+    protected function addComplexFunc() {
+        $this->tokenFactory->addFunction('lteach', function ($arg1, $arg2, $arg3, $arg4, $arg5, $arg6) {
+            if($arg6 < $arg5) {
+                return $arg4;
+            } elseif($arg6 < $arg3) {
+                return $arg2;
+            } else {
+                return $arg1;
+            }
+        }, 6);
+        $this->tokenFactory->addFunction('lteach3', function ($arg1, $arg2, $arg3, $arg4, $arg5, $arg6, $arg7, $arg8) {
+            if($arg8 < $arg7) {
+                return $arg6;
+            } elseif($arg8 < $arg5) {
+                return $arg4;
+            } elseif($arg8 < $arg3) {
+                return $arg2;
+            } else {
+                return $arg1;
+            }
+        }, 8);
+        $this->tokenFactory->addFunction('elteach', function ($arg1, $arg2, $arg3, $arg4, $arg5, $arg6) {
+            if($arg6 <= $arg5) {
+                return $arg4;
+            } elseif($arg6 <= $arg3) {
+                return $arg2;
+            } else {
+                return $arg1;
+            }
+        }, 6);
+        $this->tokenFactory->addFunction('mulgt', function ($arg1, $arg2, $arg3, $arg4, $arg5, $arg6, $arg7) {
+            if($arg7 > $arg6) {
+                if($arg5 > $arg4) {
+                    return $arg3;
+                } else {
+                    return $arg2;
+                }
+            } else {
+                return $arg1;
+            }
+        }, 7);
     }
 
     /**
@@ -140,6 +220,58 @@ class MathExecutor
     }
 
     /**
+     * Add middle result to executor
+     *
+     * @param $midresult
+     * @param $value
+     */
+    public function setMidResult($midresult, $value) {
+        $this->midresults[$midresult] = $value;
+    }
+
+    /**
+     * Add middle results to executor
+     *
+     * @param array $midresults
+     * @param bool $clear
+     * @return $this
+     */
+    public function setMidResults(array $midresults, $clear = true) {
+        if ($clear) {
+            $this->removeMidResults();
+        }
+
+        foreach($midresults as $name => $value) {
+            $this->setMidResult($name, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Remove variable from executor
+     *
+     * @param  string       $variable
+     * @return MathExecutor
+     */
+    public function removeMidResult($variable)
+    {
+        unset ($this->midresults[$variable]);
+
+        return $this;
+    }
+
+    /**
+     * Remove all variables
+     */
+    public function removeMidResults()
+    {
+        $this->midresults = array();
+
+        return $this;
+    }
+
+    /**
      * Add operator to executor
      *
      * @param  string       $operatorClass Class of operator token
@@ -184,7 +316,7 @@ class MathExecutor
             $tokens = $this->cache[$expression];
         }
         $calculator = new Calculator();
-        $result = $calculator->calculate($tokens, $this->variables);
+        $result = $calculator->calculate($tokens, $this->variables, $this->midresults, $this);
 
         return $result;
     }

--- a/tests/MathTest.php
+++ b/tests/MathTest.php
@@ -74,4 +74,14 @@ class MathTest extends \PHPUnit_Framework_TestCase
             array('100500 * 3.5E-5')
         );
     }
+
+    public function testFunction()
+    {
+        $calculator = new MathExecutor();
+
+        $calculator->addFunction('round', function ($arg) { return round($arg); }, 1);
+        /** @var float $phpResult */
+        eval('$phpResult = round(100/30);');
+        $this->assertEquals($calculator->execute('round(100/30)'), $phpResult);
+    }
 }


### PR DESCRIPTION
when a formula has more than two commas, the lexer will not correctly work.This formula 'min(log10(sqrt(10 + 1)) * max(10 - 4, 0) * max(100 - 90, 0) * 4, 40)' can reappear that bug.