### PR TITLE
Support for better invalid expression detection and divide by zero

### DIFF
--- a/src/NXP/Classes/Calculator.php
+++ b/src/NXP/Classes/Calculator.php
@@ -54,7 +54,7 @@ class Calculator
             }
         }
         $result = array_pop($stack);
-        if (!empty($stack)) {
+        if ($result === null || ! empty($stack)) {
             throw new IncorrectExpressionException();
         }
 

--- a/src/NXP/Classes/Token/TokenDegree.php
+++ b/src/NXP/Classes/Token/TokenDegree.php
@@ -10,6 +10,8 @@
 
 namespace NXP\Classes\Token;
 
+use NXP\Exception\IncorrectExpressionException;
+
 /**
 * @author Alexander Kiryukhin <alexander@symdev.org>
 */
@@ -41,12 +43,20 @@ class TokenDegree extends AbstractOperator
 
     /**
      * @param InterfaceToken[] $stack
+     *
      * @return TokenNumber
+     *
+     * @throws \NXP\Exception\IncorrectExpressionException
      */
     public function execute(&$stack)
     {
         $op2 = array_pop($stack);
         $op1 = array_pop($stack);
+
+        if ($op1 === null || $op2 === null) {
+            throw new IncorrectExpressionException("Power operator requires two operators");
+        }
+
         $result = $op1->getValue() ** $op2->getValue();
 
         return new TokenNumber($result);

--- a/src/NXP/Classes/Token/TokenDivision.php
+++ b/src/NXP/Classes/Token/TokenDivision.php
@@ -10,6 +10,9 @@
 
 namespace NXP\Classes\Token;
 
+use NXP\Exception\IncorrectExpressionException;
+use NXP\Exception\DivisionByZeroException;
+
 /**
 * @author Alexander Kiryukhin <alexander@symdev.org>
 */
@@ -41,12 +44,25 @@ class TokenDivision extends AbstractOperator
 
     /**
      * @param InterfaceToken[] $stack
+     *
      * @return $this
+     *
+     * @throws \NXP\Exception\IncorrectExpressionException
+     * @throws \NXP\Exception\DivisionByZeroException
      */
     public function execute(&$stack)
     {
         $op2 = array_pop($stack);
         $op1 = array_pop($stack);
+
+        if ($op1 === null || $op2 === null) {
+            throw new IncorrectExpressionException("Division requires two operators");
+        }
+
+        if ($op2->getValue() == 0){
+            throw new DivisionByZeroException();
+        }
+
         $result = $op2->getValue() != 0 ? $op1->getValue() / $op2->getValue() : 0;
 
         return new TokenNumber($result);

--- a/src/NXP/Classes/Token/TokenDivision.php
+++ b/src/NXP/Classes/Token/TokenDivision.php
@@ -59,10 +59,6 @@ class TokenDivision extends AbstractOperator
             throw new IncorrectExpressionException("Division requires two operators");
         }
 
-        if ($op2->getValue() == 0){
-            throw new DivisionByZeroException();
-        }
-
         $result = $op2->getValue() != 0 ? $op1->getValue() / $op2->getValue() : 0;
 
         return new TokenNumber($result);

--- a/src/NXP/Classes/Token/TokenMinus.php
+++ b/src/NXP/Classes/Token/TokenMinus.php
@@ -10,6 +10,8 @@
 
 namespace NXP\Classes\Token;
 
+use NXP\Exception\IncorrectExpressionException;
+
 /**
 * @author Alexander Kiryukhin <alexander@symdev.org>
 */
@@ -41,12 +43,20 @@ class TokenMinus extends AbstractOperator
 
     /**
      * @param InterfaceToken[] $stack
+     *
      * @return $this
+     *
+     * @throws \NXP\Exception\IncorrectExpressionException
      */
     public function execute(&$stack)
     {
         $op2 = array_pop($stack);
         $op1 = array_pop($stack);
+
+        if ($op1 === null || $op2 === null) {
+            throw new IncorrectExpressionException("Subtraction requires two operators");
+        }
+
         $result = $op1->getValue() - $op2->getValue();
 
         return new TokenNumber($result);

--- a/src/NXP/Classes/Token/TokenMultiply.php
+++ b/src/NXP/Classes/Token/TokenMultiply.php
@@ -10,6 +10,8 @@
 
 namespace NXP\Classes\Token;
 
+use NXP\Exception\IncorrectExpressionException;
+
 /**
 * @author Alexander Kiryukhin <alexander@symdev.org>
 */
@@ -41,12 +43,20 @@ class TokenMultiply extends AbstractOperator
 
     /**
      * @param InterfaceToken[] $stack
+     *
      * @return $this
+     *
+     * @throws \NXP\Exception\IncorrectExpressionException
      */
     public function execute(&$stack)
     {
         $op2 = array_pop($stack);
         $op1 = array_pop($stack);
+
+        if ($op1 === null || $op2 === null) {
+            throw new IncorrectExpressionException("Multiplication requires two operators");
+        }
+
         $result = $op1->getValue() * $op2->getValue();
 
         return new TokenNumber($result);

--- a/src/NXP/Classes/Token/TokenPlus.php
+++ b/src/NXP/Classes/Token/TokenPlus.php
@@ -10,6 +10,8 @@
 
 namespace NXP\Classes\Token;
 
+use NXP\Exception\IncorrectExpressionException;
+
 /**
 * @author Alexander Kiryukhin <alexander@symdev.org>
 */
@@ -41,12 +43,20 @@ class TokenPlus extends AbstractOperator
 
     /**
      * @param InterfaceToken[] $stack
+     *
      * @return $this
+     *
+     * @throws \NXP\Exception\IncorrectExpressionException
      */
     public function execute(&$stack)
     {
         $op2 = array_pop($stack);
         $op1 = array_pop($stack);
+
+        if ($op1 === null || $op2 === null) {
+            throw new IncorrectExpressionException("Addition requires two operators");
+        }
+
         $result = $op1->getValue() + $op2->getValue();
 
         return new TokenNumber($result);

--- a/src/NXP/Exception/DivisionByZeroException.php
+++ b/src/NXP/Exception/DivisionByZeroException.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This file is part of the MathExecutor package
+ *
+ * (c) Alexander Kiryukhin
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code
+ */
+
+namespace NXP\Exception;
+
+/**
+ * @author Vitaliy Zhuk <zhuk2205@gmail.com>
+ */
+class DivisionByZeroException extends MathExecutorException
+{
+}

--- a/tests/MathTest.php
+++ b/tests/MathTest.php
@@ -11,7 +11,15 @@
 
 namespace NXP\Tests;
 
-use \NXP\MathExecutor;
+use NXP\MathExecutor;
+use NXP\Exception\DivisionByZeroException;
+use NXP\Exception\IncorrectBracketsException;
+use NXP\Exception\IncorrectExpressionException;
+use NXP\Exception\MathExecutorException;
+use NXP\Exception\UnknownFunctionException;
+use NXP\Exception\UnknownOperatorException;
+use NXP\Exception\UnknownTokenException;
+use NXP\Exception\UnknownVariableException;
 
 class MathTest extends \PHPUnit_Framework_TestCase
 {
@@ -27,10 +35,25 @@ class MathTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($calculator->execute($expression), $phpResult);
     }
 
+    public function testUnknownFunctionException()
+    {
+        $calculator = new MathExecutor();
+        $this->expectException(UnknownFunctionException::class);
+        $calculator->execute('1 * fred("wilma") + 3');
+    }
+
+    public function testIncorrectExpressionException()
+    {
+        $calculator = new MathExecutor();
+        $this->expectException(IncorrectExpressionException::class);
+        $calculator->execute('1 * + ');
+    }
+
     public function testZeroDivision()
     {
         $calculator = new MathExecutor();
-        $this->assertEquals($calculator->execute('1 / 0'), 0);
+        $this->expectException(DivisionByZeroException::class);
+        $calculator->execute('1 / 0');
     }
 
     public function testExponentiation()

--- a/tests/MathTest.php
+++ b/tests/MathTest.php
@@ -52,8 +52,11 @@ class MathTest extends \PHPUnit_Framework_TestCase
     public function testZeroDivision()
     {
         $calculator = new MathExecutor();
-        $this->expectException(DivisionByZeroException::class);
-        $calculator->execute('1 / 0');
+        $this->assertEquals($calculator->execute('1 / 0'), 0);
+
+        // future version with allow for optional exceptions on divide by zero
+        // $this->expectException(DivisionByZeroException::class);
+        // $calculator->execute('1 / 0');
     }
 
     public function testExponentiation()
@@ -86,15 +89,25 @@ class MathTest extends \PHPUnit_Framework_TestCase
 
             ['(5 + 3) * -1'],
 
-            ['2+2*2'],
+            ['2- 2*2'],
+            ['2-(2*2)'],
+            ['(2- 2)*2'],
+            ['2 + 2*2'],
+            ['2+ 2*2'],
             ['(2+2)*2'],
-            ['(2+2)*-2'],
+            ['(2 + 2)*-2'],
             ['(2+-2)*2'],
 
             ['sin(10) * cos(50) / min(10, 20/2)'],
 
             ['100500 * 3.5E5'],
             ['100500 * 3.5E-5'],
+
+            ['-1 + -2'],
+            ['-1+-2'],
+            ['-1- -2'],
+            ['-1/-2'],
+            ['-1*-2'],
         ];
     }
 


### PR DESCRIPTION
Invalid expressions like 1+2+ or 1+*2 are now reported and does not produce an error.  Added divide by zero support.  Also incorporated various things from other outstanding pull requests.