### PR TITLE
MathExecutor::$tokenFactory should be protected (not private)

### DIFF
--- a/src/NXP/MathExecutor.php
+++ b/src/NXP/MathExecutor.php
@@ -24,16 +24,16 @@ use NXP\Exception\UnknownVariableException;
 class MathExecutor
 {
     /**
+     * @var TokenFactory
+     */
+    protected $tokenFactory;
+    
+    /**
      * Available variables
      *
      * @var array
      */
     private $variables = [];
-
-    /**
-     * @var TokenFactory
-     */
-    private $tokenFactory;
 
     /**
      * @var array


### PR DESCRIPTION
I think, that MathExecutor::$tokenFactory visiblity should be protected (not private), because:
1) Method `MathExecutor::addDefaults()` has protected visiblity
2) It can allow to extends ans redefine your built-in operators

P.S. Also, I think it should be version 0.6.1