### PR TITLE
MathExecutor allow override default operators, functions and vars

### DIFF
--- a/src/NXP/Classes/TokenFactory.php
+++ b/src/NXP/Classes/TokenFactory.php
@@ -50,12 +50,17 @@ class TokenFactory
 
     /**
      * Add function
-     * @param string   $name
+     * @param string $name
      * @param callable $function
-     * @param int      $places
+     * @param int $places
+     * @throws \ReflectionException
      */
-    public function addFunction($name, callable $function, $places = 1)
+    public function addFunction($name, callable $function, $places = null)
     {
+        if ($places === null) {
+            $reflector = new \ReflectionFunction($function);
+            $places = $reflector->getNumberOfParameters();
+        }
         $this->functions[$name] = [$places, $function];
     }
 

--- a/src/NXP/MathExecutor.php
+++ b/src/NXP/MathExecutor.php
@@ -54,35 +54,6 @@ class MathExecutor
     }
 
     /**
-     * Set default operands and functions
-     */
-    protected function addDefaults()
-    {
-        $this->tokenFactory = new TokenFactory();
-
-        $this->tokenFactory->addOperator('NXP\Classes\Token\TokenPlus');
-        $this->tokenFactory->addOperator('NXP\Classes\Token\TokenMinus');
-        $this->tokenFactory->addOperator('NXP\Classes\Token\TokenMultiply');
-        $this->tokenFactory->addOperator('NXP\Classes\Token\TokenDivision');
-        $this->tokenFactory->addOperator('NXP\Classes\Token\TokenDegree');
-
-        $this->tokenFactory->addFunction('sin', 'sin');
-        $this->tokenFactory->addFunction('cos', 'cos');
-        $this->tokenFactory->addFunction('tn', 'tan');
-        $this->tokenFactory->addFunction('asin', 'asin');
-        $this->tokenFactory->addFunction('acos', 'acos');
-        $this->tokenFactory->addFunction('atn', 'atan');
-        $this->tokenFactory->addFunction('min', 'min', 2);
-        $this->tokenFactory->addFunction('max', 'max', 2);
-        $this->tokenFactory->addFunction('avg', function($arg1, $arg2) { return ($arg1 + $arg2) / 2; }, 2);
-
-        $this->setVars([
-            'pi' => 3.14159265359,
-            'e'  => 2.71828182846
-        ]);
-    }
-
-    /**
      * Get all vars
      *
      * @return array
@@ -261,5 +232,75 @@ class MathExecutor
         $result = $calculator->calculate($tokens, $this->variables);
 
         return $result;
+    }
+
+    /**
+     * Set default operands and functions
+     */
+    protected function addDefaults()
+    {
+        $this->tokenFactory = new TokenFactory();
+
+        foreach ($this->defaultOperators() as $operatorClass) {
+            $this->tokenFactory->addOperator($operatorClass);
+        }
+
+        foreach ($this->defaultFunctions() as $name => $callable) {
+            $this->tokenFactory->addFunction($name, $callable);
+        }
+
+        $this->setVars($this->defaultVars());
+    }
+
+    protected function defaultOperators()
+    {
+        return [
+            'NXP\Classes\Token\TokenPlus',
+            'NXP\Classes\Token\TokenMinus',
+            'NXP\Classes\Token\TokenMultiply',
+            'NXP\Classes\Token\TokenDivision',
+            'NXP\Classes\Token\TokenDegree',
+        ];
+    }
+
+    protected function defaultFunctions()
+    {
+        return [
+            'sin' => function ($arg) {
+                return sin($arg);
+            },
+            'cos' => function ($arg) {
+                return cos($arg);
+            },
+            'tn' => function ($arg) {
+                return tan($arg);
+            },
+            'asin' => function ($arg) {
+                return asin($arg);
+            },
+            'acos' => function ($arg) {
+                return acos($arg);
+            },
+            'atn' => function ($arg) {
+                return atan($arg);
+            },
+            'min' => function ($arg1, $arg2) {
+                return min($arg1, $arg2);
+            },
+            'max' => function ($arg1, $arg2) {
+                return max($arg1, $arg2);
+            },
+            'avg' => function ($arg1, $arg2) {
+                return ($arg1 + $arg2) / 2;
+            },
+        ];
+    }
+
+    protected function defaultVars()
+    {
+        return [
+            'pi' => 3.14159265359,
+            'e'  => 2.71828182846
+        ];
     }
 }


### PR DESCRIPTION
As discussed here https://github.com/NeonXP/MathExecutor/pull/35 I found good solution, without any breaking backward compabilities