### PR TITLE
TokenFactory: allowing multicharacter tokens

### DIFF
--- a/src/NXP/Classes/TokenFactory.php
+++ b/src/NXP/Classes/TokenFactory.php
@@ -133,21 +133,21 @@ class TokenFactory
     {
         $operatorsRegex = '';
         foreach ($this->operators as $operator) {
-            $operatorsRegex .= $operator::getRegex();
+            $operatorsRegex .= '|(' . $operator::getRegex() . ')';
         }
-
-        return sprintf(
-            '/(%s)|(%s)|(%s)|([%s])|(%s)|(%s)|([%s%s%s])/i',
+        $s = sprintf(
+            '/(%s)|(%s)|(%s)|(%s)|(%s)|([%s%s%s])',
             TokenNumber::getRegex(),
             TokenStringDoubleQuoted::getRegex(),
             TokenStringSingleQuoted::getRegex(),
-            $operatorsRegex,
             TokenFunction::getRegex(),
             TokenVariable::getRegex(),
             TokenLeftBracket::getRegex(),
             TokenRightBracket::getRegex(),
             TokenComma::getRegex()
         );
+        $s .= $operatorsRegex . '/i';
+        return $s;
     }
 
     /**


### PR DESCRIPTION
This simple change should allow the use of tokense made up of multiple characters. This will be useful to create for example compare operators like <, <=, >, >= that I'll add to another pull request