### PR TITLE
Fix substraction by zero bug

### DIFF
--- a/src/NXP/Classes/Lexer.php
+++ b/src/NXP/Classes/Lexer.php
@@ -78,8 +78,8 @@ class Lexer
                 // if the number starts with a minus sign, it could be a negative number, or it could be an operator grabbed by the greedy regex
                 // if previous token is an operator, then it negative, otherwise remove the minus sign and put a negative operator on the stack
                 if ($lastToken !== null) {
-                    $value = (int)$token->getValue();
-                    if ($value < 0 && ! ($lastToken instanceof AbstractOperator)) {
+                    $value = $token->getValue();
+                    if (($value < 0 || $this->isNegativeZero($value)) && ! ($lastToken instanceof AbstractOperator)) {
                         $token = new TokenNumber(abs($value));
                         $output[] = $token;
                         $output[] = new TokenMinus('-');
@@ -144,5 +144,17 @@ class Lexer
         }
 
         return $output;
+    }
+
+    /**
+     * Check if the value is a negative zero
+     *
+     * @param int|float $x The value to check
+     * @return boolean True if negative zero, false otherwise
+     */
+    private function isNegativeZero($x)
+    {
+        $floatVal = floatval($x);
+        return $floatVal === 0.0 && $floatVal ** -1 === -INF;
     }
 }

--- a/tests/MathTest.php
+++ b/tests/MathTest.php
@@ -304,4 +304,11 @@ class MathTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(-4, $calculator->execute('(-4)'));
         $this->assertEquals(1, $calculator->execute('(-4 + 5)'));
     }
+
+    public function testMinusZero()
+    {
+        $calculator = new MathExecutor();
+        $this->assertEquals(1, $calculator->execute('1 - 0'));
+        $this->assertEquals(1, $calculator->execute('1-0'));
+    }
 }


### PR DESCRIPTION
Formula with a substraction by zero throw an exception.

I fixed it by testing if zero token is negative (-0) or positif (0).