### PR TITLE
Improve autoloading, asssertions and CI trigger

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build-test:

--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,19 @@
     }
   ],
   "require": {
-    "php": ">=7.1"
+    "php": ">=7.2"
   },
   "require-dev": {
     "phpunit/phpunit": ">=8.0"
   },
   "autoload": {
-    "psr-0": {
-      "NXP": "src/"
+    "psr-4": {
+      "NXP\\": "src/NXP"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "NXP\\Tests\\": "tests/"
     }
   }
 }

--- a/tests/MathTest.php
+++ b/tests/MathTest.php
@@ -504,7 +504,7 @@ class MathTest extends TestCase
         $calculator->setVar('null', null);
         $calculator->setVar('float', 1.1);
         $calculator->setVar('string', 'string');
-        $this->assertEquals(8, count($calculator->getVars()));
+        $this->assertCount(8, $calculator->getVars());
         $this->assertEquals(true, $calculator->getVar('boolTrue'));
         $this->assertEquals(false, $calculator->getVar('boolFalse'));
         $this->assertEquals(1, $calculator->getVar('int'));


### PR DESCRIPTION
# Changed log

- Add the `pull_request` trigger on GitHub Actions.
- Since this package requires `phpunit:^8.x` version, it should let this package require minimum PHP version is `7.2`.
- Using the `assertCount` to assert expected count is same as result count.
- Since the `PSR-0` autoloading is deprecated, using the `PSR-4` autoloading for source and testing classes.