### PR TITLE
Add a custom variable validator and change the properties to protected

### DIFF
--- a/tests/MathTest.php
+++ b/tests/MathTest.php
@@ -589,6 +589,21 @@ class MathTest extends TestCase
         $calculator->setVar('resource', tmpfile());
     }
 
+    public function testSetCustomVarValidator()
+    {
+        $calculator = new MathExecutor();
+        $calculator->setVarValidationHandler(function ($name, $variable) {
+            if ($name === 'invalidVar' && $variable === 'invalid') {
+                throw new MathExecutorException("Invalid variable");
+            }
+        });
+
+        $calculator->setVar('valid', $this);
+
+        $this->expectException(MathExecutorException::class);
+        $calculator->setVar('invalidVar', 'invalid');
+    }
+
     public function testVarExists()
     {
         $calculator = new MathExecutor();


### PR DESCRIPTION
This implements the changes as discussed in #97 which allows for a custom validator without extending the class. 

Updating all properties from private to protected allows for flexibility in case the `MathExecutor` class is extended.