### PR TITLE
Added ability to escape quotes in strings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,11 @@ Expressions can contain double or single quoted strings that are evaluated the s
 ```php
 echo $executor->execute("1 + '2.5' * '.5' + myFunction('category')");
 ```
+To use reverse solidus character (\) in strings, or to use single quote character (') in a single quoted string, or to use double quote character (") in a double quoted string, you must prepend reverse solidus character (\).
+
+```php
+echo $executor->execute("countArticleSentences('My Best Article\'s Title')");
+```
 
 ## Extending MathExecutor
 You can add operators, functions and variables with the public methods in MathExecutor, but if you need to do more serious modifications to base behaviors, the easiest way to extend MathExecutor is to redefine the following methods in your derived class:

--- a/src/NXP/Classes/Tokenizer.php
+++ b/src/NXP/Classes/Tokenizer.php
@@ -50,27 +50,67 @@ class Tokenizer
 
     public function tokenize() : self
     {
-        foreach (\str_split($this->input, 1) as $ch) {
+        $isLastCharEscape = false;
+
+        foreach (\str_split($this->input) as $ch) {
             switch (true) {
                 case $this->inSingleQuotedString:
-                    if ("'" === $ch) {
-                        $this->tokens[] = new Token(Token::String, $this->stringBuffer);
-                        $this->inSingleQuotedString = false;
-                        $this->stringBuffer = '';
+                    if ('\\' === $ch) {
+                        if ($isLastCharEscape) {
+                            $this->stringBuffer .= '\\';
+                            $isLastCharEscape = false;
+                        } else {
+                            $isLastCharEscape = true;
+                        }
 
                         continue 2;
+                    } elseif ("'" === $ch) {
+                        if ($isLastCharEscape) {
+                            $this->stringBuffer .= "'";
+                            $isLastCharEscape = false;
+                        } else {
+                            $this->tokens[] = new Token(Token::String, $this->stringBuffer);
+                            $this->inSingleQuotedString = false;
+                            $this->stringBuffer = '';
+                        }
+
+                        continue 2;
+                    }
+
+                    if ($isLastCharEscape) {
+                        $this->stringBuffer .= '\\';
+                        $isLastCharEscape = false;
                     }
                     $this->stringBuffer .= $ch;
 
                     continue 2;
 
                 case $this->inDoubleQuotedString:
-                    if ('"' === $ch) {
-                        $this->tokens[] = new Token(Token::String, $this->stringBuffer);
-                        $this->inDoubleQuotedString = false;
-                        $this->stringBuffer = '';
+                    if ('\\' === $ch) {
+                        if ($isLastCharEscape) {
+                            $this->stringBuffer .= '\\';
+                            $isLastCharEscape = false;
+                        } else {
+                            $isLastCharEscape = true;
+                        }
 
                         continue 2;
+                    } elseif ('"' === $ch) {
+                        if ($isLastCharEscape) {
+                            $this->stringBuffer .= '"';
+                            $isLastCharEscape = false;
+                        } else {
+                            $this->tokens[] = new Token(Token::String, $this->stringBuffer);
+                            $this->inDoubleQuotedString = false;
+                            $this->stringBuffer = '';
+                        }
+
+                        continue 2;
+                    }
+
+                    if ($isLastCharEscape) {
+                        $this->stringBuffer .= '\\';
+                        $isLastCharEscape = false;
                     }
                     $this->stringBuffer .= $ch;
 

--- a/src/NXP/MathExecutor.php
+++ b/src/NXP/MathExecutor.php
@@ -391,8 +391,12 @@ class MathExecutor
           'atan2' => static fn($arg1, $arg2) => \atan2($arg1, $arg2),
           'atanh' => static fn($arg) => \atanh($arg),
           'atn' => static fn($arg) => \atan($arg),
-          'avg' => static function($arg1, $args) {
+          'avg' => static function($arg1, ...$args) {
               if (\is_array($arg1)){
+                  if (0 === \count($arg1)){
+                      throw new \InvalidArgumentException('Could not calculate avg for empty array!');
+                  }
+
                   return \array_sum($arg1) / \count($arg1);
               }
 
@@ -447,12 +451,18 @@ class MathExecutor
               if (! \is_array($arg1) && 0 === \count($args)){
                   throw new IncorrectNumberOfFunctionParametersException();
               }
+              elseif (\is_array($arg1) && 0 === \count($arg1)){
+                      throw new \InvalidArgumentException('Array must contain at least one element!');
+              }
 
               return \max($arg1, ...$args);
           },
           'min' => static function($arg1, ...$args) {
               if (! \is_array($arg1) && 0 === \count($args)){
                   throw new IncorrectNumberOfFunctionParametersException();
+              }
+              elseif (\is_array($arg1) && 0 === \count($arg1)){
+                  throw new \InvalidArgumentException('Array must contain at least one element!');
               }
 
               return \min($arg1, ...$args);
@@ -470,7 +480,7 @@ class MathExecutor
           'tanh' => static fn($arg) => \tanh($arg),
           'tn' => static fn($arg) => \tan($arg),
           'tg' => static fn($arg) => \tan($arg),
-          'array' => static fn(...$args) => [...$args]
+          'array' => static fn(...$args) => $args
         ];
     }
 

--- a/src/NXP/MathExecutor.php
+++ b/src/NXP/MathExecutor.php
@@ -488,7 +488,7 @@ class MathExecutor
     }
 
     /**
-     * Default variable validation, ensures that the value is a scalar.
+     * Default variable validation, ensures that the value is a scalar or array.
      * @throws MathExecutorException if the value is not a scalar
      */
     protected function defaultVarValidation(string $variable, $value) : void

--- a/tests/MathTest.php
+++ b/tests/MathTest.php
@@ -305,6 +305,29 @@ class MathTest extends TestCase
         $this->assertEquals(100, $calculator->execute('10 ^ 2'));
     }
 
+    public function testStringEscape() : void
+    {
+        $calculator = new MathExecutor();
+        $this->assertEquals("test\string", $calculator->execute('"test\string"'));
+        $this->assertEquals("\\test\string\\", $calculator->execute('"\test\string\\\\"'));
+        $this->assertEquals('\test\string\\', $calculator->execute('"\test\string\\\\"'));
+        $this->assertEquals('test\\\\string', $calculator->execute('"test\\\\\\\\string"'));
+        $this->assertEquals('test"string', $calculator->execute('"test\"string"'));
+        $this->assertEquals('test""string', $calculator->execute('"test\"\"string"'));
+        $this->assertEquals('"teststring', $calculator->execute('"\"teststring"'));
+        $this->assertEquals('teststring"', $calculator->execute('"teststring\""'));
+        $this->assertEquals("test'string", $calculator->execute("'test\'string'"));
+        $this->assertEquals("test''string", $calculator->execute("'test\'\'string'"));
+        $this->assertEquals("'teststring", $calculator->execute("'\'teststring'"));
+        $this->assertEquals("teststring'", $calculator->execute("'teststring\''"));
+
+        $calculator->addFunction('concat', static function($arg1, $arg2) {
+            return $arg1 . $arg2;
+        });
+        $this->assertEquals('test"ing', $calculator->execute('concat("test\"","ing")'));
+        $this->assertEquals("test'ing", $calculator->execute("concat('test\'','ing')"));
+    }
+
     public function testArrays() : void
     {
         $calculator = new MathExecutor();
@@ -348,11 +371,11 @@ class MathTest extends TestCase
             return [5, 3, 7, 9, 8];
         });
         $calculator->addFunction('my_avarage', static function($arg1, ...$args) {
-            if (\is_array($arg1)){
+            if (\is_array($arg1)) {
                 return \array_sum($arg1) / \count($arg1);
             }
 
-            if (0 === \count($args)){
+            if (0 === \count($args)) {
                 throw new IncorrectNumberOfFunctionParametersException();
             }
             $args = [$arg1, ...$args];

--- a/tests/MathTest.php
+++ b/tests/MathTest.php
@@ -14,7 +14,6 @@ namespace NXP\Tests;
 use Exception;
 use NXP\Exception\DivisionByZeroException;
 use NXP\Exception\IncorrectExpressionException;
-use NXP\Exception\IncorrectFunctionParameterException;
 use NXP\Exception\IncorrectNumberOfFunctionParametersException;
 use NXP\Exception\MathExecutorException;
 use NXP\Exception\UnknownFunctionException;
@@ -401,16 +400,6 @@ class MathTest extends TestCase
         });
         $this->assertEquals(\round(11.176), $calculator->execute('round(11.176)'));
         $this->assertEquals(\round(11.176, 2), $calculator->execute('round(11.176,2)'));
-    }
-
-    public function testFunctionParameterTypes() : void
-    {
-        $calculator = new MathExecutor();
-        $this->expectException(IncorrectFunctionParameterException::class);
-        $calculator->addFunction('myfunc', static function(string $name, int $age) {
-            return $name . $age;
-        });
-        $calculator->execute('myfunc(22, "John Doe")');
     }
 
     public function testFunctionIncorrectNumberOfParameters() : void

--- a/tests/MathTest.php
+++ b/tests/MathTest.php
@@ -387,6 +387,7 @@ class MathTest extends TestCase
         $this->assertEquals(1, $calculator->execute('min(1,2,3)'));
         $this->assertEquals(9, $calculator->execute('max(give_me_an_array())'));
         $this->assertEquals(3, $calculator->execute('max(1,2,3)'));
+        $this->assertEquals(20, $calculator->execute('avg(10,18,32)'));
         $calculator->setVar('monthly_salaries', [100, 200, 300]);
         $this->assertEquals([100, 200, 300], $calculator->execute('$monthly_salaries'));
         $this->assertEquals(\max([100, 200, 300]), $calculator->execute('max($monthly_salaries)'));


### PR DESCRIPTION
1. Added ability to escape quotes in strings.
_To use reverse solidus character (\\) in strings, or to use single quote character (') in a single quoted string, or to use double quote character (") in a double quoted string, you must prepend reverse solidus character (\\)._
```
$calculator = new MathExecutor();
$calculator->addFunction("countArticleWords",function (string $articleTitle){
    $articleText = getArticleTextByTitle($articleTitle);
    return str_word_count($articleText);
});
$calculator->execute("countArticleWords('My Best Article\'s Title')");
```

2. Removed type checking for customfunc arguments. It was a bad idea to check types, because php automatically tries to convert a parameter to required type and throws if it failures. On the other hand, we can check types also in callables if required.
3. Fixed a typo in avg func, added a test.