### PR TITLE
Throw an IncorrectNumberOfFunctionParametersException if a function gets more arguments than it supports

### DIFF
--- a/src/NXP/Classes/CustomFunction.php
+++ b/src/NXP/Classes/CustomFunction.php
@@ -45,7 +45,7 @@ class CustomFunction
         if ($paramCountInStack < $this->requiredParamCount) {
             throw new IncorrectNumberOfFunctionParametersException($this->name);
         }
-        if ($paramCountInStack > $this->totalParamCount && !$this->isVariadic) {
+        if ($paramCountInStack > $this->totalParamCount && ! $this->isVariadic) {
             throw new IncorrectNumberOfFunctionParametersException($this->name);
         }
         $args = [];

--- a/src/NXP/Classes/CustomFunction.php
+++ b/src/NXP/Classes/CustomFunction.php
@@ -15,6 +15,8 @@ class CustomFunction
      */
     public $function;
 
+    private bool $isVariadic;
+    private int $totalParamCount;
     private int $requiredParamCount;
 
     /**
@@ -26,7 +28,10 @@ class CustomFunction
     {
         $this->name = $name;
         $this->function = $function;
-        $this->requiredParamCount = (new ReflectionFunction($function))->getNumberOfRequiredParameters();
+        $reflection = (new ReflectionFunction($function));
+        $this->isVariadic = $reflection->isVariadic();
+        $this->totalParamCount = $reflection->getNumberOfParameters();
+        $this->requiredParamCount = $reflection->getNumberOfRequiredParameters();
 
     }
 
@@ -38,6 +43,9 @@ class CustomFunction
     public function execute(array &$stack, int $paramCountInStack) : Token
     {
         if ($paramCountInStack < $this->requiredParamCount) {
+            throw new IncorrectNumberOfFunctionParametersException($this->name);
+        }
+        if ($paramCountInStack > $this->totalParamCount && !$this->isVariadic) {
             throw new IncorrectNumberOfFunctionParametersException($this->name);
         }
         $args = [];

--- a/tests/MathTest.php
+++ b/tests/MathTest.php
@@ -674,6 +674,16 @@ class MathTest extends TestCase
         $calculator->execute('myfunc(1)');
     }
 
+    public function testFunctionIncorrectNumberOfParametersTooMany() : void
+    {
+        $calculator = new MathExecutor();
+        $this->expectException(IncorrectNumberOfFunctionParametersException::class);
+        $calculator->addFunction('myfunc', static function($arg1, $arg2) {
+            return $arg1 + $arg2;
+        });
+        $calculator->execute('myfunc(1,2,3)');
+    }
+
     public function testFunctionIf() : void
     {
         $calculator = new MathExecutor();


### PR DESCRIPTION
Throw an IncorrectNumberOfFunctionParametersException if a function gets more arguments than it supports

This solves #116 