### PR TITLE
Add support for using none default base value in log function

### DIFF
--- a/src/NXP/MathExecutor.php
+++ b/src/NXP/MathExecutor.php
@@ -468,9 +468,9 @@ class MathExecutor
               return $this->execute($falseval);
           },
           'intdiv' => static fn($arg1, $arg2) => \intdiv($arg1, $arg2),
-          'ln' => static fn($arg) => \log($arg),
+          'ln' => static fn($arg1, $arg2 = M_E) => \log($arg1, $arg2),
           'lg' => static fn($arg) => \log10($arg),
-          'log' => static fn($arg) => \log($arg),
+          'log' => static fn($arg1, $arg2 = M_E) => \log($arg1, $arg2),
           'log10' => static fn($arg) => \log10($arg),
           'log1p' => static fn($arg) => \log1p($arg),
           'max' => static function($arg1, ...$args) {

--- a/tests/MathTest.php
+++ b/tests/MathTest.php
@@ -97,6 +97,7 @@ class MathTest extends TestCase
           ['hypot(1.5, 3.5)'],
           ['intdiv(10, 2)'],
           ['log(1.5)'],
+          ['log(1.5, 3)'],
           ['log10(1.5)'],
           ['log1p(1.5)'],
           ['max(1.5, 3.5)'],
@@ -1148,6 +1149,7 @@ class MathTest extends TestCase
           ['decbin(10)', \decbin(10)],
           ['lg(2)', \log10(2)],
           ['ln(2)', \log(2)],
+          ['ln(2, 5)', \log(2, 5)],
           ['sec(4)', 1 / \cos(4)],
           ['tg(4)', \tan(4)],
         ];


### PR DESCRIPTION
The [PHP documentation](https://www.php.net/manual/en/function.log.php) for `log()` shows that it accepts an optional second argument.
This PR ensures that the optional argument can be used when using the function through the math executor.